### PR TITLE
NodeJS in AWS: Task 5: AWS Simple Storage Service - S3

### DIFF
--- a/import-service/.gitignore
+++ b/import-service/.gitignore
@@ -1,0 +1,14 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless
+
+# Webpack directories
+.webpack
+
+.vscode
+
+.idea
+*.iml

--- a/import-service/handler.ts
+++ b/import-service/handler.ts
@@ -1,0 +1,5 @@
+import 'source-map-support/register';
+import {importProductsFile} from './handlers/importProductsFile'
+import {importFileParser} from './handlers/importFileParser'
+
+export {importProductsFile, importFileParser}

--- a/import-service/handlers/cors.ts
+++ b/import-service/handlers/cors.ts
@@ -1,0 +1,4 @@
+export const corsHeaders = {
+    'Access-Control-Allow-Origin': '*', // Required for CORS support to work
+    'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
+};

--- a/import-service/handlers/importFileParser.ts
+++ b/import-service/handlers/importFileParser.ts
@@ -1,0 +1,43 @@
+import {S3Handler} from 'aws-lambda';
+import 'source-map-support/register';
+
+const AWS = require('aws-sdk');
+const csv = require('csv-parser');
+
+const s3 = new AWS.S3({region: 'eu-west-1'});
+const bucket = 'evgeny-romanov-rs-csv';
+
+export const importFileParser: S3Handler = async (event, _context) => {
+    event.Records.forEach(record => {
+        const key = record.s3.object.key;
+        console.log("Processing object", key);
+
+        const s3Stream = s3.getObject({Bucket: bucket, Key: key}).createReadStream();
+        s3Stream.on('error', error => {
+            console.log('File processing failed', error)
+        })
+
+        s3Stream
+            .pipe(csv())
+            .on('data', (data) => {
+                console.log('CSV data', data)
+            })
+            .on('end', async () => {
+                console.log('CSV parsing finished')
+                const toObject = key.replace("uploaded", "parsed");
+                console.log('Moving object to', toObject)
+                await s3.copyObject({
+                    Bucket: bucket,
+                    CopySource: `${bucket}/${key}`,
+                    Key: toObject
+                }).promise()
+                await s3.deleteObject({
+                    Bucket: bucket,
+                    Key: key
+                })
+            })
+            .on('error', error => {
+                console.log('CSV parsing failed', error)
+            });
+    })
+}

--- a/import-service/handlers/importProductsFile.ts
+++ b/import-service/handlers/importProductsFile.ts
@@ -1,0 +1,30 @@
+import {APIGatewayProxyHandler} from 'aws-lambda';
+import 'source-map-support/register';
+import {corsHeaders} from "./cors";
+
+const AWS = require('aws-sdk');
+
+const s3 = new AWS.S3({region: 'eu-west-1'});
+const bucket = 'evgeny-romanov-rs-csv';
+
+export const importProductsFile: APIGatewayProxyHandler = async (event, _context) => {
+    console.log(event);
+    if (!event.queryStringParameters) {
+        return {statusCode: 400, headers: corsHeaders, body: JSON.stringify({error: "Missing query parameters"}, null, 2)}
+    }
+    const {name} = event.queryStringParameters;
+    if (!name) {
+        return {statusCode: 400, headers: corsHeaders, body: JSON.stringify({error: "Missing file name"}, null, 2)}
+    }
+
+
+
+    const parameters = {
+        Bucket: bucket,
+        Key: `uploaded/${name}`,
+        Expires: 60,
+        ContentType: 'text/csv'
+    }
+    const url = await s3.getSignedUrlPromise('putObject', parameters);
+    return {statusCode: 200, headers: corsHeaders, body: JSON.stringify(url, null, 2)}
+}

--- a/import-service/package.json
+++ b/import-service/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "import-service",
+  "version": "1.0.0",
+  "description": "Serverless webpack example using Typescript",
+  "main": "handler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.792.0",
+    "csv-parser": "^2.3.3",
+    "source-map-support": "^0.5.10"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.17",
+    "@types/node": "^10.12.18",
+    "@types/serverless": "^1.72.5",
+    "fork-ts-checker-webpack-plugin": "^3.0.1",
+    "serverless-webpack": "^5.2.0",
+    "ts-loader": "^5.3.3",
+    "ts-node": "^8.10.2",
+    "typescript": "^3.2.4",
+    "webpack": "^4.29.0",
+    "webpack-node-externals": "^1.7.2"
+  },
+  "author": "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",
+  "license": "MIT"
+}

--- a/import-service/serverless.ts
+++ b/import-service/serverless.ts
@@ -1,0 +1,82 @@
+import type {Serverless} from 'serverless/aws';
+
+const serverlessConfiguration: Serverless = {
+    service: {
+        name: 'import-service',
+        // app and org for use with dashboard.serverless.com
+        // app: your-app-name,
+        // org: your-org-name,
+    },
+    frameworkVersion: '2',
+    custom: {
+        webpack: {
+            webpackConfig: './webpack.config.js',
+            includeModules: true
+        }
+    },
+    // Add the serverless-webpack plugin
+    plugins: ['serverless-webpack'],
+    provider: {
+        name: 'aws',
+        runtime: 'nodejs12.x',
+        stage: 'dev',
+        region: 'eu-west-1',
+        apiGateway: {
+            minimumCompressionSize: 1024,
+        },
+        environment: {
+            AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+        },
+        iamRoleStatements: [
+            {
+                Effect: 'Allow',
+                Action: 's3:ListBucket',
+                Resource: 'arn:aws:s3:::evgeny-romanov-rs-csv'
+            },
+            {
+                Effect: 'Allow',
+                Action: 's3:*',
+                Resource: 'arn:aws:s3:::evgeny-romanov-rs-csv/*'
+            }
+        ]
+    },
+    functions: {
+        importProductsFile: {
+            handler: 'handler.importProductsFile',
+            events: [
+                {
+                    http: {
+                        method: 'get',
+                        path: 'import',
+                        cors: true,
+                        request: {
+                            parameters: {
+                                querystrings: {
+                                    name: true
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        importFileParser: {
+            handler: 'handler.importFileParser',
+            events: [
+                {
+                    s3: {
+                        bucket: 'evgeny-romanov-rs-csv',
+                        event: 's3:ObjectCreated:*',
+                        rules: [{
+                            prefix: 'uploaded',
+                            suffix: '',
+                        }],
+                        existing: true
+                    }
+                }
+            ]
+        }
+    }
+}
+
+module.exports = serverlessConfiguration;

--- a/import-service/tsconfig.json
+++ b/import-service/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "lib": ["es2017"],
+    "removeComments": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "sourceMap": true,
+    "target": "es2017",
+    "outDir": "lib"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": [
+    "node_modules/**/*",
+    ".serverless/**/*",
+    ".webpack/**/*",
+    "_warmup/**/*",
+    ".vscode/**/*"
+  ]
+}

--- a/import-service/webpack.config.js
+++ b/import-service/webpack.config.js
@@ -1,0 +1,51 @@
+const path = require('path');
+const slsw = require('serverless-webpack');
+const nodeExternals = require('webpack-node-externals');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+
+module.exports = {
+  context: __dirname,
+  mode: slsw.lib.webpack.isLocal ? 'development' : 'production',
+  entry: slsw.lib.entries,
+  devtool: slsw.lib.webpack.isLocal ? 'cheap-module-eval-source-map' : 'source-map',
+  resolve: {
+    extensions: ['.mjs', '.json', '.ts'],
+    symlinks: false,
+    cacheWithContext: false,
+  },
+  output: {
+    libraryTarget: 'commonjs',
+    path: path.join(__dirname, '.webpack'),
+    filename: '[name].js',
+  },
+  target: 'node',
+  externals: [nodeExternals()],
+  module: {
+    rules: [
+      // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
+      {
+        test: /\.(tsx?)$/,
+        loader: 'ts-loader',
+        exclude: [
+          [
+            path.resolve(__dirname, 'node_modules'),
+            path.resolve(__dirname, '.serverless'),
+            path.resolve(__dirname, '.webpack'),
+          ],
+        ],
+        options: {
+          transpileOnly: true,
+          experimentalWatchApi: true,
+        },
+      },
+    ],
+  },
+  plugins: [
+    // new ForkTsCheckerWebpackPlugin({
+    //   eslint: true,
+    //   eslintOptions: {
+    //     cache: true
+    //   }
+    // })
+  ],
+};


### PR DESCRIPTION
Added two lambdas:
1) importProductsFile to provide upload URL to S3 bucket
2) importFileParser to parse uploaded CSV file

Mandatory tasks:
- [x]  File serverless.yml contains configuration for importProductsFile function
- [x]  The importProductsFile lambda function returns a correct response which can be used to upload a file into the S3 bucket
- [x]  Frontend application is integrated with importProductsFile lambda
- [x]  The importFileParser lambda function is implemented and serverless.yml contains configuration for the lambda

Optional tasks:
- [x]  async/await is used in lambda functions
- [ ]  importProductsFile lambda is covered by unit tests (aws-sdk-mock can be used to mock S3 methods - https://www.npmjs.com/package/aws-sdk-mock)
- [x]  At the end of the stream the lambda function should move the file from the uploaded folder into the parsed folder (move the file means that file should be copied into parsed folder, and then deleted from uploaded folder)

PR for frontend: evgeny-romanov-epam/nodejs-aws-fe#4
Link to FE: https://d1jsj1buphbw19.cloudfront.net/